### PR TITLE
added JSF C++ coding standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Docs
 * [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
 * [High Integrity Coding Standard](http://www.codingstandard.com/section/index/).
 * [SEI CERT C++ Coding Standard](https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=637).
+* [JSF Air Vehicle - C++ Coding Standards (Revision C)](http://www.stroustrup.com/JSF-AV-rules.pdf).
 
 ### Clojure
 * [The Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide) - A community coding style guide for the Clojure programming language.


### PR DESCRIPTION
Finally I found the download link. =:-)

How do you think about coding standards that are not available for free, but influence the respective industry a lot, like MISRA C (https://en.wikipedia.org/wiki/MISRA_C) and MISRA C++ (http://www.misra-cpp.com)?
